### PR TITLE
fix: entrypoint에서 실행 파일명 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY /build/libs/cicd-0.0.1-SNAPSHOT.jar /app/cicd-0.0.1-SNAPSHOT.jar
 
 # jar 파일 실행
-ENTRYPOINT ["java", "-jar", "/app/canchem.jar"]
+ENTRYPOINT ["java", "-jar", "/app/cicd-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
entrypoint에서 실행할 .jar 파일을 컨테이너 내 생성한 .jar 파일명으로 변경